### PR TITLE
Fix: Remove header title and subtitle from UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,11 +11,6 @@
   </head>
   <body>
     <div class="container">
-      <header>
-        <h1>Course Materials Assistant</h1>
-        <p class="subtitle">Ask questions about courses, instructors, and content</p>
-      </header>
-
       <div class="main-content">
         <!-- Left Sidebar -->
         <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -139,27 +139,6 @@ body {
   padding: 0;
 }
 
-/* Header - Hidden */
-header {
-  display: none;
-}
-
-header h1 {
-  font-size: 1.75rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin: 0;
-}
-
-.subtitle {
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-  margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
   flex: 1;
@@ -827,14 +806,6 @@ details[open] .suggested-header::before {
 
   .chat-main {
     order: 1;
-  }
-
-  header {
-    padding: 1rem;
-  }
-
-  header h1 {
-    font-size: 1.5rem;
   }
 
   .chat-messages {


### PR DESCRIPTION
Removes the "Course Materials Assistant" header, subtitle, and associated CSS rules per issue #7. Theme toggle is kept intact.

Generated with [Claude Code](https://claude.ai/code)